### PR TITLE
Add plan id metadata to payment URLs

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -28,11 +28,14 @@ PLAN_LINK_IDS = {
     "Full Year Experience": "LNK_253P067SB1"
 }
 
-def generate_bold_link(link_id: str, user_id: int) -> str:
+def generate_bold_link(link_id: str, user_id: int, plan_id: str) -> str:
+    """Generate a Bold.co payment URL including the plan identifier."""
+
     return (
         f"https://checkout.bold.co/payment/{link_id}"
         f"?identity_key={BOLD_IDENTITY_KEY}"
         f"&metadata[user_id]={user_id}"
+        f"&metadata[plan_id]={plan_id}"
     )
 
 # Channel settings

--- a/bot/payment_webhook.py
+++ b/bot/payment_webhook.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from fastapi import FastAPI, Request, HTTPException
 from telegram import Bot
-from bot.config import BOT_TOKEN
+from bot.config import BOT_TOKEN, PLANS
 from bot.subscriber_manager import subscriber_manager
 from bot.payment_links import payment_generator
 import logging
@@ -15,8 +15,9 @@ async def handle_payment_webhook(request: Request):
         
         # Extract payment info (adjust based on your payment provider)
         transaction_id = data.get("transaction_id")
-        user_id = data.get("user_id") 
-        plan_id = data.get("plan")
+        user_id = data.get("user_id")
+        metadata = data.get("metadata", {})
+        plan_id = metadata.get("plan_id")
         status = data.get("status")
         
         if status == "completed" and transaction_id:
@@ -24,13 +25,19 @@ async def handle_payment_webhook(request: Request):
             payment_info = payment_generator.verify_payment_link(transaction_id)
             
             if payment_info:
+                # Look up plan name using identifier
+                plan_info = PLANS.get(plan_id)
+                if not plan_info:
+                    raise ValueError(f"Unknown plan id: {plan_id}")
+                plan_name = plan_info["name"]
+
                 # Mark payment as completed
-                payment_generator.mark_payment_completed(transaction_id)
-                
+                payment_generator.mark_payment_completed(user_id, plan_name)
+
                 # Add subscriber
                 success = subscriber_manager.add_subscriber(
                     user_id=user_id,
-                    plan_id=plan_id,
+                    plan_name=plan_name,
                     transaction_id=transaction_id
                 )
                 
@@ -39,10 +46,10 @@ async def handle_payment_webhook(request: Request):
                     bot = Bot(token=BOT_TOKEN)
                     await bot.send_message(
                         chat_id=user_id,
-                        text=f"✅ Payment confirmed! Your {plan_id} subscription is now active."
+                        text=f"✅ Payment confirmed! Your {plan_name} subscription is now active."
                     )
                     
-                    logger.info(f"Payment confirmed for user {user_id}, plan {plan_id}")
+                    logger.info(f"Payment confirmed for user {user_id}, plan {plan_name}")
                     return {"status": "success"}
         
         return {"status": "ignored"}


### PR DESCRIPTION
## Summary
- include plan identifiers when generating payment links
- track the identifier in PaymentLinkGenerator
- read the identifier in the payment webhook and look up the plan name

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e2f4c89508332981de5d7475e6613

## Summary by Sourcery

Include plan ID metadata in payment link generation and update the webhook handler to extract that ID, map it to the plan name, and use the name for downstream processing and notifications.

New Features:
- Attach plan_id in generated payment URLs metadata
- Extract plan_id from webhook metadata and look up the corresponding plan name
- Pass resolved plan name to subscriber manager and confirmation messages

Enhancements:
- Store plan_id in active payment link records
- Update generate_bold_link signature to include plan_id