### PR TITLE
Fix env token setup variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def setup():
         BOT_TOKEN = input("Enter your Telegram bot token: ").strip()
         ADMIN_ID = input("Enter your Telegram user ID: ").strip()
 
-        env_content = f"""BOT_TOKEN={bot_token}
+        env_content = f"""BOT_TOKEN={BOT_TOKEN}
 ADMIN_IDS=7940478393
 ADMIN_PORT=8080
 ADMIN_HOST=0.0.0.0


### PR DESCRIPTION
## Summary
- fix variable name when creating `.env` in `setup.py`

## Testing
- `printf "TESTTOKEN123\n12345\n" | python setup.py`


------
https://chatgpt.com/codex/tasks/task_e_684e484f4c9883328d6a633c30d19c9c

## Summary by Sourcery

Bug Fixes:
- Use the uppercase BOT_TOKEN variable instead of bot_token when writing to .env in setup.py