### PR TITLE
Make subscriber database async

### DIFF
--- a/bot/admin.py
+++ b/bot/admin.py
@@ -20,7 +20,7 @@ async def admin_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             await update.message.reply_text(TEXTS["en"]["admin_only"])
             return
 
-        stats = subscriber_manager.get_stats()
+        stats = await subscriber_manager.get_stats()
         keyboard = [
             [InlineKeyboardButton("📊 Statistics", callback_data="admin_stats")],
             [InlineKeyboardButton("🌐 Web Panel", url=f"http://{ADMIN_HOST}:{ADMIN_PORT}")],
@@ -45,7 +45,7 @@ async def stats_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             await update.message.reply_text(TEXTS["en"]["admin_only"])
             return
 
-        stats = subscriber_manager.get_stats()
+        stats = await subscriber_manager.get_stats()
         text = (
             "📊 **Bot Statistics**\n\n"
             f"👥 Total users: {stats['total']}\n"

--- a/bot/admin_panel.py
+++ b/bot/admin_panel.py
@@ -29,7 +29,7 @@ async def payment_webhook(request: Request):
 async def get_stats():
     """Get bot statistics"""
     try:
-        stats = subscriber_manager.get_stats()
+        stats = await subscriber_manager.get_stats()
         return {"success": True, "data": stats}
     except Exception as e:
         logger.error(f"Error getting stats: {e}")

--- a/bot/callbacks.py
+++ b/bot/callbacks.py
@@ -291,7 +291,7 @@ async def show_admin_stats(query, user_id):
         await query.edit_message_text("⛔ Unauthorized access")
         return
     
-    stats = subscriber_manager.get_stats()
+    stats = await subscriber_manager.get_stats()
 
     text = (
         "📊 **Bot Statistics**\n\n"

--- a/bot/payment_webhook.py
+++ b/bot/payment_webhook.py
@@ -35,7 +35,7 @@ async def handle_payment_webhook(request: Request):
                 payment_generator.mark_payment_completed(user_id, plan_name)
 
                 # Add subscriber
-                success = subscriber_manager.add_subscriber(
+                success = await subscriber_manager.add_subscriber(
                     user_id=user_id,
                     plan_name=plan_name,
                     transaction_id=transaction_id

--- a/bot/subscriber_manager.py
+++ b/bot/subscriber_manager.py
@@ -1,10 +1,11 @@
 # bot/subscriber_manager.py
-"""Manage subscriber data using a PostgreSQL database."""
+"""Manage subscriber data using a PostgreSQL database asynchronously."""
 
-import psycopg2
+import asyncio
 from datetime import datetime, timedelta
 from typing import Dict, List
 
+import asyncpg
 from bot.config import CHANNELS, PLANS, BOT_TOKEN, DATABASE_URL
 from telegram import Bot
 
@@ -13,12 +14,14 @@ class SubscriberManager:
     def __init__(self, db_url: str = DATABASE_URL):
         if not db_url:
             raise ValueError("DATABASE_URL must be provided")
-        self.conn = psycopg2.connect(db_url)
-        self._ensure_table()
+        self.db_url = db_url
+        loop = asyncio.get_event_loop()
+        self.pool = loop.run_until_complete(asyncpg.create_pool(dsn=db_url))
+        loop.run_until_complete(self._ensure_table())
 
-    def _ensure_table(self) -> None:
-        with self.conn.cursor() as cur:
-            cur.execute(
+    async def _ensure_table(self) -> None:
+        async with self.pool.acquire() as conn:
+            await conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS subscribers (
                     user_id BIGINT PRIMARY KEY,
@@ -29,7 +32,6 @@ class SubscriberManager:
                 )
                 """
             )
-        self.conn.commit()
 
     async def add_subscriber(self, user_id: int, plan_name: str, transaction_id: str = None) -> bool:
         try:
@@ -45,20 +47,23 @@ class SubscriberManager:
             start_date = datetime.utcnow()
             expiry_date = start_date + timedelta(days=duration_days)
 
-            with self.conn.cursor() as cur:
-                cur.execute(
+            async with self.pool.acquire() as conn:
+                await conn.execute(
                     """
                     INSERT INTO subscribers (user_id, plan, start_date, expires_at, transaction_id)
-                    VALUES (%s, %s, %s, %s, %s)
+                    VALUES ($1, $2, $3, $4, $5)
                     ON CONFLICT (user_id) DO UPDATE SET
                         plan=EXCLUDED.plan,
                         start_date=EXCLUDED.start_date,
                         expires_at=EXCLUDED.expires_at,
                         transaction_id=EXCLUDED.transaction_id
                     """,
-                    (user_id, plan_name, start_date, expiry_date, transaction_id),
+                    user_id,
+                    plan_name,
+                    start_date,
+                    expiry_date,
+                    transaction_id,
                 )
-            self.conn.commit()
 
             bot = Bot(token=BOT_TOKEN)
             for channel in CHANNELS.values():
@@ -71,20 +76,19 @@ class SubscriberManager:
             print(f"Error adding subscriber: {e}")
             return False
 
-    def get_all(self) -> List[Dict]:
-        with self.conn.cursor() as cur:
-            cur.execute("SELECT user_id, expires_at FROM subscribers")
-            rows = cur.fetchall()
+    async def get_all(self) -> List[Dict]:
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("SELECT user_id, expires_at FROM subscribers")
         return [
             {"user_id": row[0], "expires_at": row[1]} for row in rows
         ]
 
-    def get_stats(self) -> Dict[str, int]:
-        with self.conn.cursor() as cur:
-            cur.execute("SELECT COUNT(*) FROM subscribers")
-            total = cur.fetchone()[0]
-            cur.execute("SELECT COUNT(*) FROM subscribers WHERE expires_at > NOW()")
-            active = cur.fetchone()[0]
+    async def get_stats(self) -> Dict[str, int]:
+        async with self.pool.acquire() as conn:
+            total = await conn.fetchval("SELECT COUNT(*) FROM subscribers")
+            active = await conn.fetchval(
+                "SELECT COUNT(*) FROM subscribers WHERE expires_at > NOW()"
+            )
         return {"total": total, "active": active}
 
 

--- a/bot/utils/expiration_task.py
+++ b/bot/utils/expiration_task.py
@@ -10,7 +10,7 @@ async def check_expired_users():
     expired_users = []
     now = datetime.now()
 
-    for record in subscriber_manager.get_all():
+    for record in await subscriber_manager.get_all():
         exp_date = record["expires_at"]
         if exp_date < now:
             expired_users.append(record["user_id"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ gspread==6.2.1
 python-dotenv==1.0.1
 apscheduler==3.11.0
 oauth2client==4.1.3
-psycopg2-binary==2.9.9
+asyncpg==0.30.0
+


### PR DESCRIPTION
## Summary
- use `asyncpg` for database operations
- update SubscriberManager for async database calls
- await SubscriberManager in bot handlers
- use asyncpg dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853109d1d2c83328cc3b80942d4d016