### PR TITLE
Fix invite method

### DIFF
--- a/bot/subscriber_manager.py
+++ b/bot/subscriber_manager.py
@@ -63,9 +63,13 @@ class SubscriberManager:
             bot = Bot(token=BOT_TOKEN)
             for channel in CHANNELS.values():
                 try:
-                    await bot.invite_chat_member(chat_id=channel, user_id=user_id)
+                    invite_link = await bot.export_chat_invite_link(chat_id=channel)
+                    await bot.send_message(
+                        chat_id=user_id,
+                        text=f"Join {channel}: {invite_link}",
+                    )
                 except Exception as e:
-                    print(f"Error adding user {user_id} to {channel}: {e}")
+                    print(f"Error inviting user {user_id} to {channel}: {e}")
             return True
         except Exception as e:
             print(f"Error adding subscriber: {e}")

--- a/tests/test_subscriber_manager.py
+++ b/tests/test_subscriber_manager.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+import importlib
+import sys
+
+# Provide fake DB connection before importing the module
+class FakeCursor:
+    def execute(self, *args, **kwargs):
+        pass
+    def fetchall(self):
+        return []
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+class FakeConn:
+    def cursor(self):
+        return FakeCursor()
+    def commit(self):
+        pass
+
+with patch('psycopg2.connect', return_value=FakeConn()):
+    if 'bot.subscriber_manager' in sys.modules:
+        importlib.reload(sys.modules['bot.subscriber_manager'])
+    else:
+        import bot.subscriber_manager
+from bot.subscriber_manager import SubscriberManager
+
+class TestSubscriberManager(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        class TestManager(SubscriberManager):
+            def __init__(self):
+                self.conn = FakeConn()
+        self.manager = TestManager()
+
+    async def test_add_subscriber_invite(self):
+        with patch('bot.subscriber_manager.Bot') as MockBot:
+            mock_bot = MockBot.return_value
+            mock_bot.export_chat_invite_link = AsyncMock(return_value='link')
+            mock_bot.send_message = AsyncMock()
+            with patch('bot.subscriber_manager.PLANS', {'trial': {'name': 'Trial', 'duration_days': 1}}), \
+                 patch('bot.subscriber_manager.CHANNELS', {'main': '@channel'}):
+                result = await self.manager.add_subscriber(user_id=1, plan_name='Trial')
+                self.assertTrue(result)
+                mock_bot.export_chat_invite_link.assert_called_with(chat_id='@channel')
+                mock_bot.send_message.assert_called_with(chat_id=1, text='Join @channel: link')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace unsupported invite_chat_member with export_chat_invite_link and send_message
- add regression test for add_subscriber invite flow

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6853109794f483329556c26736cade41