### PR TITLE
Initialize expiration scheduler in main

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -146,17 +146,16 @@ def main():
     application.add_handler(CallbackQueryHandler(handlers.handle_callback))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.handle_persistent_buttons))
 
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    from bot.utils.expiration_task import check_expired_users
+
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(check_expired_users, "interval", hours=24)
+    scheduler.start()
+
     print("🤖 Bot running...")
     application.run_polling(allowed_updates=Update.ALL_TYPES)
 
 if __name__ == '__main__':
     main()
-
-import asyncio
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from bot.utils.expiration_task import check_expired_users
-
-scheduler = AsyncIOScheduler()
-scheduler.add_job(check_expired_users, "interval", hours=24)
-scheduler.start()
 


### PR DESCRIPTION
## Summary
- move expiration scheduler setup into `main`
- remove leftover scheduler code at module level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530b21c2c8833285db74283f844eda