### PR TITLE
Fix async subscriber addition

### DIFF
--- a/bot/payment_webhook.py
+++ b/bot/payment_webhook.py
@@ -28,7 +28,7 @@ async def handle_payment_webhook(request: Request):
                 payment_generator.mark_payment_completed(transaction_id)
                 
                 # Add subscriber
-                success = subscriber_manager.add_subscriber(
+                success = await subscriber_manager.add_subscriber(
                     user_id=user_id,
                     plan_id=plan_id,
                     transaction_id=transaction_id


### PR DESCRIPTION
## Summary
- await `subscriber_manager.add_subscriber` in payment webhook

## Testing
- `python3 -m py_compile bot/payment_webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_684e4846a6dc8332876ae4aaafea8403