### PR TITLE
Fix env token variable in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def setup():
         BOT_TOKEN = input("Enter your Telegram bot token: ").strip()
         ADMIN_ID = input("Enter your Telegram user ID: ").strip()
 
-        env_content = f"""BOT_TOKEN={bot_token}
+        env_content = f"""BOT_TOKEN={BOT_TOKEN}
 ADMIN_IDS=7940478393
 ADMIN_PORT=8080
 ADMIN_HOST=0.0.0.0


### PR DESCRIPTION
## Summary
- fix BOT_TOKEN variable reference in setup.py

## Testing
- `python3 setup.py <<EOF
12345:mytoken
9999
EOF`
- `cat .env`

------
https://chatgpt.com/codex/tasks/task_e_684e4741daa88332ac174c63e25ce57e