### PR TITLE
Use supported method to add subscribers to channels

### DIFF
--- a/bot/subscriber_manager.py
+++ b/bot/subscriber_manager.py
@@ -63,7 +63,7 @@ class SubscriberManager:
             bot = Bot(token=BOT_TOKEN)
             for channel in CHANNELS.values():
                 try:
-                    await bot.invite_chat_member(chat_id=channel, user_id=user_id)
+                    await bot.add_chat_members(chat_id=channel, user_ids=[user_id])
                 except Exception as e:
                     print(f"Error adding user {user_id} to {channel}: {e}")
             return True


### PR DESCRIPTION
## Summary
- switch to `add_chat_members` when adding users to a channel

## Testing
- `python -m py_compile bot/subscriber_manager.py`
- `flake8 bot/subscriber_manager.py` *(fails: E501 line too long)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68530b236cec8332860b1682e83de002