### PR TITLE
Update tests for asyncpg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ uvicorn==0.27.0
 python-dotenv==1.0.1
 apscheduler==3.11.0
 psycopg2-binary==2.9.9
+asyncpg==0.30.0


### PR DESCRIPTION
## Summary
- ensure `tests` can import repository modules
- mock `asyncpg` pool in tests
- add `asyncpg` to dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853136d2348833291bea7df3b8c8f43