### PR TITLE
Add helpful error message when asyncpg missing

### DIFF
--- a/bot/subscriber_manager.py
+++ b/bot/subscriber_manager.py
@@ -5,7 +5,12 @@ import asyncio
 from datetime import datetime, timedelta
 from typing import Dict, List
 
-import asyncpg
+try:
+    import asyncpg
+except ImportError as exc:
+    raise ImportError(
+        "asyncpg is required. Install dependencies using 'pip install -r requirements.txt'"
+    ) from exc
 from bot.config import CHANNELS, PLANS, BOT_TOKEN, DATABASE_URL
 from telegram import Bot
 


### PR DESCRIPTION
## Summary
- raise informative ImportError if asyncpg is not installed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853199c48f88332b4f22442a1da0073