### PR TITLE
docs: note start module usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Other channel IDs can be defined in `bot/config.py` if multiple channels are use
 * `python run_admin.py` – launch the FastAPI admin panel.
 * `python run_simple_bot.py` – start the simplified subscription bot.
 
+`bot/start.py` only defines command handlers. Run `python run_bot.py` from the
+project root to start the full bot; executing `bot/start.py` directly will fail
+with `ModuleNotFoundError: bot`.
+
 ## Deploying on Railway
 
 A [`railway.json`](railway.json) configuration is provided.  To deploy:

--- a/bot/start.py
+++ b/bot/start.py
@@ -4,6 +4,13 @@ from telegram.ext import ContextTypes
 import logging
 from bot.texts import TEXTS
 
+
+if __name__ == "__main__":
+    print("This module provides Telegram command handlers and isn't intended "
+          "to be executed directly.\n"
+          "Run 'python run_bot.py' from the project root to start the bot.")
+    exit(1)
+
 logger = logging.getLogger(__name__)
 
 async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
## Summary by Sourcery

Prevent executing bot/start.py directly by adding a __main__ guard that prints usage instructions and update documentation to guide users to launch the bot via run_bot.py instead of running the start module.

Enhancements:
- Add __main__ guard in bot/start.py to display an error message when executed directly

Documentation:
- Update README to note that bot/start.py defines command handlers and must be launched with python run_bot.py