### PR TITLE
docs: note start module usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Other channel IDs can be defined in `bot/config.py` if multiple channels are use
 * `python run_admin.py` – launch the FastAPI admin panel.
 * `python run_simple_bot.py` – start the simplified subscription bot.
 
+`bot/start.py` only defines command handlers. Run `python run_bot.py` from the
+project root to start the full bot; executing `bot/start.py` directly will fail
+with `ModuleNotFoundError: bot`.
+
 ## Deploying on Railway
 
 A [`railway.json`](railway.json) configuration is provided.  To deploy:
@@ -53,4 +57,14 @@ A [`railway.json`](railway.json) configuration is provided.  To deploy:
 2. Set all required environment variables in the Railway dashboard.
 3. The project will build using Python 3.11 and run `python run_bot.py` as specified in `railway.json`.
 4. Deploy the service.  Railway will restart the bot on failure as configured.
+
+Railway automatically installs the dependencies listed in
+[`requirements.txt`](requirements.txt) when building the project. If the bot
+fails with `No module named 'asyncpg'` it usually means the dependencies were
+not installed. Re‑deploy or run `pip install -r requirements.txt` locally to
+verify the environment.
+
+If the bot exits with `ConnectionRefusedError` during startup, the PostgreSQL
+server may not be reachable. Verify that `DATABASE_URL` points to a running
+database that accepts connections.
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -5,9 +5,15 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Bot settings
+import sys
+
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 if not BOT_TOKEN:
-    raise ValueError("BOT_TOKEN must be set in .env file")
+    # When running under pytest, allow a dummy token to avoid import errors
+    if "pytest" in sys.modules or any("pytest" in arg for arg in sys.argv):
+        BOT_TOKEN = "TEST_TOKEN"
+    else:
+        raise ValueError("BOT_TOKEN must be set in .env file")
 
 # Parse ADMIN_IDS
 admin_ids_str = os.getenv("ADMIN_IDS", "")
@@ -21,7 +27,10 @@ if admin_ids_str:
 # Payment settings
 BOLD_IDENTITY_KEY = os.getenv("BOLD_IDENTITY_KEY")
 if not BOLD_IDENTITY_KEY:
-    raise ValueError("BOLD_IDENTITY_KEY must be set in .env file")
+    if "pytest" in sys.modules or any("pytest" in arg for arg in sys.argv):
+        BOLD_IDENTITY_KEY = "TEST_KEY"
+    else:
+        raise ValueError("BOLD_IDENTITY_KEY must be set in .env file")
 
 PLAN_LINK_IDS = {
     "Trial Trip": "LNK_O7C5LTPYFP",

--- a/bot/start.py
+++ b/bot/start.py
@@ -4,6 +4,13 @@ from telegram.ext import ContextTypes
 import logging
 from bot.texts import TEXTS
 
+
+if __name__ == "__main__":
+    print("This module provides Telegram command handlers and isn't intended "
+          "to be executed directly.\n"
+          "Run 'python run_bot.py' from the project root to start the bot.")
+    exit(1)
+
 logger = logging.getLogger(__name__)
 
 async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/run_admin.py
+++ b/run_admin.py
@@ -5,8 +5,18 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
 if __name__ == "__main__":
-    from bot.admin_panel import app
+    try:
+        from bot.admin_panel import app
+    except (ModuleNotFoundError, ImportError) as e:
+        if getattr(e, 'name', '') == 'asyncpg':
+            print("❌ Error: asyncpg is not installed. Run 'pip install -r requirements.txt'")
+        else:
+            print(f"❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        raise
     
     port = int(os.getenv("ADMIN_PORT", 8080))
     host = os.getenv("ADMIN_HOST", "0.0.0.0")

--- a/run_bot.py
+++ b/run_bot.py
@@ -67,6 +67,13 @@ def main():
         print("✅ Bot starting...")
         app.run_polling(drop_pending_updates=True)
 
+    except (ModuleNotFoundError, ImportError) as e:
+        if e.name == "asyncpg":
+            print("❌ Error: asyncpg is not installed. Run 'pip install -r requirements.txt'")
+        else:
+            print(f"❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
     except Exception as e:
         print(f"❌ Error: {e}")
         import traceback


### PR DESCRIPTION
## Summary
- clarify that `bot/start.py` is not executable
- add an explanatory message when it is run directly
- relax env var requirements when running under tests
- avoid SubscriberManager DB init during tests
- hint to install dependencies if `asyncpg` is missing
- handle ImportError as well as ModuleNotFoundError in startup scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853199c48f88332b4f22442a1da0073

## Summary by Sourcery

Clarify startup usage and improve error handling and test support across the bot’s entry points

Enhancements:
- Guard bot/start.py to print a usage message and exit when run directly
- Wrap asyncpg pool creation to surface connection failures with a clear message
- Catch both ModuleNotFoundError and ImportError in run_admin.py and run_bot.py to provide dependency install hints

Documentation:
- Update README to note that bot/start.py isn’t executable and add troubleshooting tips for missing asyncpg and database connectivity

Tests:
- Allow dummy BOT_TOKEN and BOLD_IDENTITY_KEY under pytest and skip SubscriberManager initialization during tests