### PR TITLE
Fix subscriber manager test patches

### DIFF
--- a/tests/test_subscriber_manager.py
+++ b/tests/test_subscriber_manager.py
@@ -44,8 +44,7 @@ class FakePool:
 async def fake_create_pool(*args, **kwargs):
     return FakePool()
 
-with patch('asyncpg.create_pool', side_effect=fake_create_pool), \
-     patch('psycopg2.connect', return_value=FakeConn()):
+with patch('asyncpg.create_pool', side_effect=fake_create_pool):
     if 'bot.subscriber_manager' in sys.modules:
         importlib.reload(sys.modules['bot.subscriber_manager'])
     else:


### PR DESCRIPTION
## Summary
- remove unused psycopg2 patch in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c7f51ce48332ac9e81bb262c74de

## Summary by Sourcery

Tests:
- Remove patch for psycopg2.connect in tests/test_subscriber_manager.py