### PR TITLE
Clean up setup helper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 import os
 
+# Helper script to create a minimal `.env` file with the required
+# environment variables for the bot.
+
 def setup():
+    """Interactive helper to create a basic `.env` file."""
+
     print("PNP Television Bot Ultimate - Setup")
     print("=" * 40)
 
@@ -10,12 +15,10 @@ def setup():
         BOT_TOKEN = input("Enter your Telegram bot token: ").strip()
         ADMIN_ID = input("Enter your Telegram user ID: ").strip()
 
-        env_content = f"""BOT_TOKEN={BOT_TOKEN}
-ADMIN_IDS=7940478393
-ADMIN_PORT=8080
-ADMIN_HOST=0.0.0.0
-GOOGLE_CREDENTIALS_JSON=credentials.json
-"""  # triple comillas escapadas
+        env_content = (
+            f"BOT_TOKEN={BOT_TOKEN}\n"
+            f"ADMIN_IDS={ADMIN_ID}\n"
+        )
 
         with open('.env', 'w', encoding='utf-8') as f:
             f.write(env_content)


### PR DESCRIPTION
## Summary
- document that `setup.py` just creates a minimal `.env`
- write admin ID to the env file and drop unused variable

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q psycopg2-binary`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853c7f35cc083328571185deb23eade

## Summary by Sourcery

Clean up the setup helper by simplifying .env file generation, documenting its purpose, and dropping unused variables.

Enhancements:
- Add comments and docstring to clarify that setup.py creates a minimal .env file
- Generate ADMIN_IDS dynamically instead of using a hardcoded value
- Remove unused environment variables (ADMIN_PORT, ADMIN_HOST, GOOGLE_CREDENTIALS_JSON) from the generated .env