### PR TITLE
Finalize plan names and fix timezone

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -34,11 +34,11 @@ if not BOLD_IDENTITY_KEY:
 
 PLAN_LINK_IDS = {
     "Trial Trip": "LNK_O7C5LTPYFP",
-    "Monthly Adventure": "LNK_52ZQ7A0I9I",
+    "Cloudy Month": "LNK_52ZQ7A0I9I",
     "Frequent Flyer": "LNK_468D3W49LB",
-    "Half-Year Escape": "LNK_EMVGMPYMGJ",
-    "Full Year Experience": "LNK_253P067SB1",
-    "Lifetime Access": "LNK_PNM53KLD99"
+    "Slam Surfer": "LNK_EMVGMPYMGJ",
+    "Full Year": "LNK_253P067SB1",
+    "PNP Forever": "LNK_PNM53KLD99"
 }
 
 def generate_bold_link(link_id: str, user_id: int, plan_id: str) -> str:
@@ -73,7 +73,7 @@ PLANS = {
         "link_id": "LNK_O7C5LTPYFP"
     },
     "monthly": {
-        "name": "Monthly Adventure", 
+        "name": "Cloudy Month",
         "price": "$24.99",
         "duration_days": 30,
         "link_id": "LNK_52ZQ7A0I9I"
@@ -85,19 +85,19 @@ PLANS = {
         "link_id": "LNK_468D3W49LB"
     },
     "halfyear": {
-        "name": "Half-Year Escape",
+        "name": "Slam Surfer",
         "price": "$79.99",
         "duration_days": 180,
         "link_id": "LNK_EMVGMPYMGJ"
     },
     "yearly": {
-        "name": "Full Year Experience",
+        "name": "Full Year",
         "price": "$99.99",
         "duration_days": 365,
         "link_id": "LNK_253P067SB1"
     },
     "lifetime": {
-        "name": "Lifetime Access",
+        "name": "PNP Forever",
         "price": "$249.99",
         "duration_days": 3650,
         "link_id": "LNK_PNM53KLD99"

--- a/bot/main.py
+++ b/bot/main.py
@@ -80,7 +80,8 @@ class BotHandlers:
             "• ☁️ Cloudy Month — $24.99 / 30 días\n"
             "• 🔁 Frequent Flyer — $49.99 / 3 meses\n"
             "• 🏄 Slam Surfer — $79.99 / 6 meses\n"
-            "• 🌐 Full Year — $99.99 / 12 meses"
+            "• 🌐 Full Year — $99.99 / 12 meses\n"
+            "• 💎 PNP Forever — $249.99 / lifetime"
         )
         keyboard = [[InlineKeyboardButton("🔙 Back / Atrás", callback_data='back_main')]]
         await query.edit_message_text(text=text, reply_markup=InlineKeyboardMarkup(keyboard))

--- a/bot/simple_subscription_bot.py
+++ b/bot/simple_subscription_bot.py
@@ -25,37 +25,37 @@ CHANNEL_NAME = os.getenv("CHANNEL_NAME", "PNP Television")
 # Plan definitions
 PLANS = {
     "week": {
-        "name": "WEEK PASS",
+        "name": "Trial Trip",
         "price": "$14.99",
         "days": 7,
         "description": "Acceso total a PNP TV por 7 días 🔥"
     },
     "month": {
-        "name": "MONTH PASS",
+        "name": "Cloudy Month",
         "price": "$24.99",
         "days": 30,
         "description": "Un mes entero de placer visual sin límites 💦"
     },
     "3month": {
-        "name": "3 MONTH PASS",
+        "name": "Frequent Flyer",
         "price": "$49.99",
         "days": 90,
         "description": "3 meses de acceso VIP. ¡Ahorra y disfruta más! 💎"
     },
     "halfyear": {
-        "name": "1/2 YEAR PASS",
+        "name": "Slam Surfer",
         "price": "$79.99",
         "days": 180,
         "description": "6 meses de acceso full a la experiencia PNP 🔥🔥"
     },
     "year": {
-        "name": "1 YEAR PASS",
+        "name": "Full Year",
         "price": "$99.99",
         "days": 365,
         "description": "Todo un año con los shows más calientes de PNP 🖤"
     },
     "lifetime": {
-        "name": "LIFETIME PASS",
+        "name": "PNP Forever",
         "price": "$249.99",
         "days": 3650,
         "description": "Acceso ilimitado y de por vida a todo el contenido 💀"

--- a/bot/subscriber_manager.py
+++ b/bot/subscriber_manager.py
@@ -2,7 +2,7 @@
 """Manage subscriber data using a PostgreSQL database asynchronously."""
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List
 
 try:
@@ -55,7 +55,8 @@ class SubscriberManager:
                 return False
 
             duration_days = plan_info["duration_days"]
-            start_date = datetime.utcnow()
+            # Use timezone-aware UTC datetime to avoid deprecation warning
+            start_date = datetime.now(timezone.utc)
             expiry_date = start_date + timedelta(days=duration_days)
 
             async with self.pool.acquire() as conn:


### PR DESCRIPTION
## Summary
- unify subscription plan names across codebase
- list lifetime plan in main menu
- use timezone-aware datetime in subscriber manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863741391448332b8bbbe090f395c78